### PR TITLE
Divesh/deploy chain 1

### DIFF
--- a/src/contexts/PactContext.js
+++ b/src/contexts/PactContext.js
@@ -20,7 +20,7 @@ export class PactStore extends React.Component {
     round: 1,
     players: [],
     playersData: [],
-    chainId: 0,
+    chainId: 1,
     hosts: 0,
     currentReqKey: "",
     payoutMatrix: {},
@@ -116,7 +116,7 @@ export class PactStore extends React.Component {
               ],
               sender: this.state.playerId,
               gasLimit: 10000,
-              chainId: "0",
+              chainId: "1",
               ttl: 28800,
               envData: {}
             }
@@ -161,7 +161,7 @@ export class PactStore extends React.Component {
             ],
             sender: this.state.playerId,
             gasLimit: 10000,
-            chainId: "0",
+            chainId: "1",
             ttl: 28800,
             envData: {}
           }
@@ -207,7 +207,7 @@ export class PactStore extends React.Component {
             ],
             sender: this.state.playerId,
             gasLimit: 10000,
-            chainId: "0",
+            chainId: "1",
             ttl: 28800,
             envData: {}
           }

--- a/src/contexts/PactContext.js
+++ b/src/contexts/PactContext.js
@@ -107,7 +107,7 @@ export class PactStore extends React.Component {
         //   "0",
         //   100000
           const signCmd = {
-              pactCode: `(user.pacty-parrots-two.start-round ${JSON.stringify(this.state.playerId)})`,
+              pactCode: `(free.pacty-parrots-two.start-round ${JSON.stringify(this.state.playerId)})`,
               // pactCode: `(coin.transfer "sender01" "sender00" 1.0)`,
               caps: [
                 Pact.lang.mkCap("Gas capability", "description of gas cap", "coin.GAS", []),
@@ -154,7 +154,7 @@ export class PactStore extends React.Component {
       //   const reqKey = await Pact.wallet.sendSigned(cmd, createAPIHost(this.state.workingHosts[0], "0"))
       try {
         const signCmd = {
-            pactCode: `(user.pacty-parrots-two.continue-round ${JSON.stringify(this.state.playerId)})`,
+            pactCode: `(free.pacty-parrots-two.continue-round ${JSON.stringify(this.state.playerId)})`,
             // pactCode: `(coin.transfer "sender01" "sender00" 1.0)`,
             caps: [
               Pact.lang.mkCap("Gas capability", "description of gas cap", "coin.GAS", []),
@@ -199,7 +199,7 @@ export class PactStore extends React.Component {
       //   const reqKey = await Pact.wallet.sendSigned(cmd, createAPIHost(this.state.workingHosts[0], "0"))
       try {
         const signCmd = {
-            pactCode: `(user.pacty-parrots-two.end-round ${JSON.stringify(this.state.playerId)})`,
+            pactCode: `(free.pacty-parrots-two.end-round ${JSON.stringify(this.state.playerId)})`,
             // pactCode: `(coin.transfer "sender01" "sender00" 1.0)`,
             caps: [
               Pact.lang.mkCap("Gas capability", "description of gas cap", "coin.GAS", []),
@@ -252,7 +252,7 @@ export class PactStore extends React.Component {
 
   getPlayerTable = async () => {
     const cmd = await Pact.fetch.local({
-      pactCode: `(user.pacty-parrots-two.get-table ${JSON.stringify(this.state.playerId)})`,
+      pactCode: `(free.pacty-parrots-two.get-table ${JSON.stringify(this.state.playerId)})`,
       keyPairs: dumKeyPair,
     }, createAPIHost(this.state.workingHosts[0], "0"))
     // .then(res => {
@@ -267,7 +267,7 @@ export class PactStore extends React.Component {
   getAllPlayerTables = async () => {
     const l = await this.getAllPlayers();
     const cmd = await Pact.fetch.local({
-      pactCode: `(map (user.pacty-parrots-two.get-table) ${JSON.stringify(l)})`,
+      pactCode: `(map (free.pacty-parrots-two.get-table) ${JSON.stringify(l)})`,
       keyPairs: dumKeyPair,
     }, createAPIHost(this.state.workingHosts[0], "0"))
     const data = await cmd.data;


### PR DESCRIPTION
Switch to running on chain 1. The faucet https://faucet.testnet.chainweb.com/ creates and funds accounts on chain 1 and pacty-parrots runs on chain 0. This means a user would have to do a cross-chain-transfer-create to chain 0 from chain 1 (or something similar). To avoid this we just deploy the `pacty-parrots` module on chain 1 and change the context so this works. 